### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  pages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wenyichen/chart-creator-app/security/code-scanning/2](https://github.com/wenyichen/chart-creator-app/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow. Since the workflow deploys to GitHub Pages, it likely requires `contents: read` and `pages: write` permissions. These permissions should be added at the root level of the workflow to apply to all jobs unless overridden. This change ensures that the `GITHUB_TOKEN` has only the necessary permissions, reducing the risk of misuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
